### PR TITLE
Fix metrics namespace and task weight handling

### DIFF
--- a/packages/node/internal/jsonrpc.go
+++ b/packages/node/internal/jsonrpc.go
@@ -127,7 +127,8 @@ func logResponse(logger *log.Entry, reqID string, duration time.Duration, status
 // NewJSONRPCHandler constructs a Handler instance
 func NewJSONRPCHandler(params HandlerParams) Handler {
 	taskStore := params.TaskStore
-	// TODO(lark): should cleanup
+	// GPU provider store automatically cleans up outdated entries whenever
+	// providers are listed via ListGPUProviders.
 	gps := store.NewGPUProviderStore()
 	ethC, err := ethclient.Dial(rpcURL)
 	if err != nil {
@@ -340,7 +341,7 @@ func NewJSONRPCHandler(params HandlerParams) Handler {
 
 func decorateHandlers(logger *log.Entry, m handler.Map) handler.Map {
 	requestMetric := prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Namespace:  "TODO_cuckoo_node",
+		Namespace:  "cuckoo_node",
 		Subsystem:  "json_rpc",
 		Name:       "request_duration_seconds",
 		Help:       "JSON RPC request duration",

--- a/packages/node/internal/store/task_store.go
+++ b/packages/node/internal/store/task_store.go
@@ -246,8 +246,8 @@ func (store *InMemoryTaskStore) GetPendingTasksByWeights(weights []WalletWeight,
 	})
 
 	total := totalWeight(weights)
-	// TODO: what if no weight at all? just return all tasks for now
-	if total.Cmp(big.NewInt(0)) == 0 {
+	// If there are no weights or they sum to zero, simply return all tasks.
+	if len(weights) == 0 || total.Cmp(big.NewInt(0)) == 0 {
 		return offers
 	}
 

--- a/packages/node/internal/store/task_store_test.go
+++ b/packages/node/internal/store/task_store_test.go
@@ -87,6 +87,20 @@ func TestGetPendingTasksByWeightsOneTaskTwoWorkers(t *testing.T) {
 	require.Equal(t, 1, len(uniqueTasks), "The number of total unique tasks should be 1")
 }
 
+func TestGetPendingTasksByWeightsNoWeights(t *testing.T) {
+	s := store.NewInMemoryTaskStore()
+
+	task1 := &store.TaskOffer{Id: "task1", Status: store.Pending, CoinSymbol: plugins.SD, MaxOfferPrice: big.NewInt(100), CreatedAt: time.Now()}
+	task2 := &store.TaskOffer{Id: "task2", Status: store.Pending, CoinSymbol: plugins.SD, MaxOfferPrice: big.NewInt(200), CreatedAt: time.Now()}
+
+	s.Create(task1)
+	s.Create(task2)
+
+	// Empty weights should return all pending tasks
+	result := s.GetPendingTasksByWeights([]store.WalletWeight{}, "wallet1")
+	require.Equal(t, 2, len(result))
+}
+
 func parseBigInt(input string) *big.Int {
 	// Create a new big.Int instance initialized to zero
 	bigInt := new(big.Int)


### PR DESCRIPTION
## Summary
- use `cuckoo_node` namespace for metrics
- clarify GPU provider store cleanup logic
- properly handle empty weight list in GetPendingTasksByWeights
- test new weight handling behavior

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840eb4b7518832c9bb3521680793f0f