### PR TITLE
Fix accessibility issues in home package

### DIFF
--- a/packages/home/docs/deploy-smart-contract/using-remix.md
+++ b/packages/home/docs/deploy-smart-contract/using-remix.md
@@ -46,7 +46,7 @@ Make sure to open the advanced configurations and set the EVM version to London.
 
 
 
-<img src="https://cuckoo-network.b-cdn.net/using-remix3.webp" style={{height: "500px"}} />
+<img src="https://cuckoo-network.b-cdn.net/using-remix3.webp" style={{height: "500px"}} alt="Remix compile tab" />
 
 
 
@@ -58,9 +58,9 @@ In the "Environment" dropdown menu, select "Injected Provider - MetaMask". This 
 
 Make sure to have Cuckoo Chain as your selected network in MetaMask before deploying.
 
-<img src="https://cuckoo-network.b-cdn.net/using-remix3.webp" style={{height: "500px"}} />
+<img src="https://cuckoo-network.b-cdn.net/using-remix3.webp" style={{height: "500px"}} alt="Remix deploy tab" />
 
-<img src="https://cuckoo-network.b-cdn.net/using-remix4.webp" style={{height: "500px"}} />
+<img src="https://cuckoo-network.b-cdn.net/using-remix4.webp" style={{height: "500px"}} alt="Select environment" />
 
 
 
@@ -68,7 +68,7 @@ Select the compiled contract you want to deploy and click 'Deploy'.
 
 Now, MetaMask should pop up and ask you to confirm the transaction with super low fees.
 
-<img src="https://cuckoo-network.b-cdn.net/using-remix5.webp" style={{height: "500px"}} />
+<img src="https://cuckoo-network.b-cdn.net/using-remix5.webp" style={{height: "500px"}} alt="Confirm deploy transaction" />
 
 
 
@@ -84,7 +84,7 @@ You will see your deployed smart contract below in the 'Deploy & Run Transaction
 
 We can also find our deployed smart contract in [Blockscout](https://testnet-scan.cuckoo.network/), the Cuckoo block scanner. Copy the contract address from Remix, go to [Blockscout](https://testnet-scan.cuckoo.network/), and paste it into the search bar.
 
-<img src="https://cuckoo-network.b-cdn.net/using-remix6.webp" style={{height: "500px"}} />
+<img src="https://cuckoo-network.b-cdn.net/using-remix6.webp" style={{height: "500px"}} alt="Explore contract on Blockscout" />
 
 
 

--- a/packages/home/src/pages/brand-assets.mdx
+++ b/packages/home/src/pages/brand-assets.mdx
@@ -86,37 +86,37 @@ Learn how to use brand assets and showcase content from Cuckoo technologies and 
   <div className="col"><h2 style={{margin: 0}}>Logo</h2></div>
   <div className="col">
     <div>Icon only PNG 👇</div>
-    <img style={{width: "48px"}} src="/img/favicon.png"/>
+    <img style={{width: "48px"}} src="/img/favicon.png" alt="Cuckoo favicon"/>
     <div>Icon only PNG 👇</div>
-    <img style={{width: "48px"}} src="/img/favicon-black.png"/>
+    <img style={{width: "48px"}} src="/img/favicon-black.png" alt="Cuckoo favicon black"/>
         <div>Icon only SVG 👇</div>
-        <img style={{width: "48px"}} src="/img/favicon.svg"/>
+        <img style={{width: "48px"}} src="/img/favicon.svg" alt="Cuckoo favicon SVG"/>
 
     <div>Icon + Text PNG 👇</div>
     <div style={{backgroundColor: "black", padding: "20px", display: "inline-block", marginBottom: "10px"}}>
-      <img src="https://cuckoo-network.b-cdn.net/white-full-logo.png"/>
+      <img src="https://cuckoo-network.b-cdn.net/white-full-logo.png" alt="Cuckoo white logo"/>
     </div>
     <div>Icon + Text SVG 👇</div>
     <div style={{backgroundColor: "black", padding: "20px", display: "inline-block"}}>
-      <img src="https://cuckoo-network.b-cdn.net/white-full-logo.svg"/>
+      <img src="https://cuckoo-network.b-cdn.net/white-full-logo.svg" alt="Cuckoo white logo SVG"/>
     </div>
     <div>Icon + Text PNG 👇 white text</div>
     <img style={{backgroundColor: "white", padding: "8px"}}
-         src="https://cuckoo-network.b-cdn.net/black-full-logo.png"/>
+         src="https://cuckoo-network.b-cdn.net/black-full-logo.png" alt="Cuckoo black logo"/>
     <div>Icon + Text SVG 👇 white text</div>
     <img style={{backgroundColor: "white", padding: "8px"}}
-         src="https://cuckoo-network.b-cdn.net/black-full-logo.svg"/>
+         src="https://cuckoo-network.b-cdn.net/black-full-logo.svg" alt="Cuckoo black logo SVG"/>
 
     <div>Pattern Logo 👇</div>
-    <img src="https://cuckoo-network.b-cdn.net/cuckoo-pattern-logo.png"/>
+    <img src="https://cuckoo-network.b-cdn.net/cuckoo-pattern-logo.png" alt="Cuckoo pattern logo"/>
 
     <div>Preview Banner 👇</div>
     <img
-         src="https://cuckoo-network.b-cdn.net/cuckoo-ai-banner-v2.png"/>
+         src="https://cuckoo-network.b-cdn.net/cuckoo-ai-banner-v2.png" alt="Cuckoo banner"/>
 
     <div>Preview Banner short 👇</div>
     <img
-         src="https://cuckoo-network.b-cdn.net/cuckoo-ai-banner.png"/>
+         src="https://cuckoo-network.b-cdn.net/cuckoo-ai-banner.png" alt="Cuckoo short banner"/>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- add missing `alt` text for brand images
- document alt text for screenshots in smart contract guide

## Testing
- `yarn typecheck` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68591e6fd430832c80c27207d037759b